### PR TITLE
Fix bug when using conversation with async call

### DIFF
--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -53,7 +53,7 @@ def resolve_type(attachment):
     return mime_type
 
 
-class _SharedGeminiBase:
+class _SharedGemini:
     needs_key = "gemini"
     key_env_var = "LLM_GEMINI_KEY"
     can_stream = True
@@ -129,15 +129,53 @@ class _SharedGeminiBase:
             ge=1,
         )
         json_object: Optional[bool] = Field(
-            description="Output a valid JSON object {...}", default=None,
+            description="Output a valid JSON object {...}",
+            default=None,
         )
 
     def __init__(self, model_id):
         self.model_id = model_id
 
-    def build_request_body(self, prompt, messages):
+    def build_messages(self, prompt, conversation):
+        messages = []
+        if conversation:
+            for response in conversation.responses:
+                parts = []
+                for attachment in response.attachments:
+                    mime_type = resolve_type(attachment)
+                    parts.append(
+                        {
+                            "inlineData": {
+                                "data": attachment.base64_content(),
+                                "mimeType": mime_type,
+                            }
+                        }
+                    )
+                if response.prompt.prompt:
+                    parts.append({"text": response.prompt.prompt})
+                messages.append({"role": "user", "parts": parts})
+                messages.append({"role": "model", "parts": [{"text": response.text_or_raise()}]})
+
+        parts = []
+        if prompt.prompt:
+            parts.append({"text": prompt.prompt})
+        for attachment in prompt.attachments:
+            mime_type = resolve_type(attachment)
+            parts.append(
+                {
+                    "inlineData": {
+                        "data": attachment.base64_content(),
+                        "mimeType": mime_type,
+                    }
+                }
+            )
+
+        messages.append({"role": "user", "parts": parts})
+        return messages
+
+    def build_request_body(self, prompt, conversation):
         body = {
-            "contents": messages,
+            "contents": self.build_messages(prompt, conversation),
             "safetySettings": SAFETY_SETTINGS,
         }
         if prompt.options and prompt.options.code_execution:
@@ -189,96 +227,19 @@ class _SharedGeminiBase:
             pass
 
 
-class _SyncGeminiMixin(_SharedGeminiBase):
-    def build_messages(self, prompt, conversation):
-        messages = []
-        if conversation:
-            for response in conversation.responses:
-                parts = []
-                for attachment in response.attachments:
-                    mime_type = resolve_type(attachment)
-                    parts.append(
-                        {
-                            "inlineData": {
-                                "data": attachment.base64_content(),
-                                "mimeType": mime_type,
-                            }
-                        }
-                    )
-                if response.prompt.prompt:
-                    parts.append({"text": response.prompt.prompt})
-                messages.append({"role": "user", "parts": parts})
-                messages.append({"role": "model", "parts": [{"text": response.text()}]})
-
-        parts = []
-        if prompt.prompt:
-            parts.append({"text": prompt.prompt})
-        for attachment in prompt.attachments:
-            mime_type = resolve_type(attachment)
-            parts.append(
-                {
-                    "inlineData": {
-                        "data": attachment.base64_content(),
-                        "mimeType": mime_type,
-                    }
-                }
-            )
-
-        messages.append({"role": "user", "parts": parts})
-        return messages
-
-
-class _AsyncGeminiMixin(_SharedGeminiBase):
-    async def build_messages(self, prompt, conversation):
-        messages = []
-        if conversation:
-            for response in conversation.responses:
-                parts = []
-                for attachment in response.attachments:
-                    mime_type = resolve_type(attachment)
-                    parts.append(
-                        {
-                            "inlineData": {
-                                "data": attachment.base64_content(),
-                                "mimeType": mime_type,
-                            }
-                        }
-                    )
-                if response.prompt.prompt:
-                    parts.append({"text": response.prompt.prompt})
-                messages.append({"role": "user", "parts": parts})
-                messages.append(
-                    {"role": "model", "parts": [{"text": await response.text()}]}
-                )
-
-        parts = []
-        if prompt.prompt:
-            parts.append({"text": prompt.prompt})
-        for attachment in prompt.attachments:
-            mime_type = resolve_type(attachment)
-            parts.append(
-                {
-                    "inlineData": {
-                        "data": attachment.base64_content(),
-                        "mimeType": mime_type,
-                    }
-                }
-            )
-
-        messages.append({"role": "user", "parts": parts})
-        return messages
-
-
-class GeminiPro(_SyncGeminiMixin, llm.Model):
+class GeminiPro(_SharedGemini, llm.Model):
     def execute(self, prompt, stream, response, conversation):
         key = self.get_key()
         url = f"https://generativelanguage.googleapis.com/v1beta/models/{self.model_id}:streamGenerateContent"
         gathered = []
-        messages = self.build_messages(prompt, conversation)
-        body = self.build_request_body(prompt, messages)
+        body = self.build_request_body(prompt, conversation)
 
         with httpx.stream(
-            "POST", url, timeout=None, headers={"x-goog-api-key": key}, json=body,
+            "POST",
+            url,
+            timeout=None,
+            headers={"x-goog-api-key": key},
+            json=body,
         ) as http_response:
             events = ijson.sendable_list()
             coro = ijson.items_coro(events, "item")
@@ -299,17 +260,20 @@ class GeminiPro(_SyncGeminiMixin, llm.Model):
         self.set_usage(response)
 
 
-class AsyncGeminiPro(_AsyncGeminiMixin, llm.AsyncModel):
+class AsyncGeminiPro(_SharedGemini, llm.AsyncModel):
     async def execute(self, prompt, stream, response, conversation):
         key = self.get_key()
         url = f"https://generativelanguage.googleapis.com/v1beta/models/{self.model_id}:streamGenerateContent"
         gathered = []
-        messages = await self.build_messages(prompt, conversation)
-        body = self.build_request_body(prompt, messages)
+        body = self.build_request_body(prompt, conversation)
 
         async with httpx.AsyncClient() as client:
             async with client.stream(
-                "POST", url, timeout=None, headers={"x-goog-api-key": key}, json=body,
+                "POST",
+                url,
+                timeout=None,
+                headers={"x-goog-api-key": key},
+                json=body,
             ) as http_response:
                 events = ijson.sendable_list()
                 coro = ijson.items_coro(events, "item")


### PR DESCRIPTION
Reference:
- https://github.com/simonw/llm/issues/674

This fixes the bug reported in the above issue where there was an error while using async conversation. 

As [stated here](https://github.com/simonw/llm/issues/674#issuecomment-2550739764) With llm-gemini, the request body is built [here](https://github.com/simonw/llm-gemini/blob/439ef69a83f239b492d653bcfde104be37095bdc/llm_gemini.py#L268), which in turn tries to get the text from previous responses in the conversation [here](https://github.com/simonw/llm-gemini/blob/439ef69a83f239b492d653bcfde104be37095bdc/llm_gemini.py#L157). But because the response is an instance of AsyncResponse, we get the error coroutine 'AsyncResponse.text' was never awaited.



Code to test that fix works is 

```python

import asyncio
import llm

model = llm.get_async_model("gemini-2.0-flash-exp")

conversation = model.conversation()

async def run():
    response = await conversation.prompt("joke")
    text = await response.text()
    response2 = await conversation.prompt("again")
    text2 = await response2.text()
    print(text, text2)

asyncio.run(run())

```