### PR TITLE
Add support for textual file attachments

### DIFF
--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -60,6 +60,9 @@ class _SharedGemini:
     can_stream = True
 
     attachment_types = (
+        # Text
+        "text/plain",
+        "text/csv",
         # PDF
         "application/pdf",
         # Images


### PR DESCRIPTION
This PR adds support for attaching textual files with mimetypes `text/plain` and `text/csv`.

(`text/plain` is explicitly supported as for [docs](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#blob), `text/csv` works as tested by me)