### PR TITLE
add model "learnlm-1.5-pro-experimental"

### DIFF
--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -42,6 +42,7 @@ def register_models(register):
         "gemini-exp-1206",
         "gemini-2.0-flash-exp",
         "gemini-2.0-flash-thinking-exp-1219",
+        "learnlm-1.5-pro-experimental"
     ]:
         register(GeminiPro(model_id), AsyncGeminiPro(model_id))
 

--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -41,7 +41,7 @@ def register_models(register):
         "gemini-exp-1121",
         "gemini-exp-1206",
         "gemini-2.0-flash-exp",
-        "learnlm-1.5-pro-experimental"
+        "learnlm-1.5-pro-experimental",
         "gemini-2.0-flash-thinking-exp-1219",
         "gemini-2.0-flash-thinking-exp-01-21",
     ]:


### PR DESCRIPTION
see https://ai.google.dev/gemini-api/docs/models/experimental-models for all available experimental models. learnlm was missing from the list in the plugin