### PR TITLE
Use google_search not google_search_retrieval

### DIFF
--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -216,7 +216,7 @@ class _SharedGemini:
         if prompt.options and prompt.options.code_execution:
             body["tools"] = [{"codeExecution": {}}]
         if prompt.options and self.can_google_search and prompt.options.google_search:
-            body["tools"] = [{"google_search_retrieval": {}}]
+            body["tools"] = [{"google_search": {}}]
         if prompt.system:
             body["systemInstruction"] = {"parts": [{"text": prompt.system}]}
 


### PR DESCRIPTION
Google recommended using the google_search field instead of google_search_retrieval. I don't know if it's only for experimental models.

 llm -m gemini-2.0-flash-exp -o google_search 1   'What is the latest version of pydantic?'

Error: Unable to submit request because Please use google_search field instead of google_search_retrieval field.. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini