### PR TITLE
Add grounding sources and search suggestions

### DIFF
--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -1,3 +1,4 @@
+from bs4 import BeautifulSoup
 import httpx
 import ijson
 import llm
@@ -71,6 +72,13 @@ def resolve_type(attachment):
     if mime_type == "application/ogg":
         mime_type = "audio/ogg"
     return mime_type
+
+
+def format_link(osc8format, title, link):
+    if osc8format:
+        return f"\x1b]8;;{link}\a{title}\x1b]8;;\a"
+    else:
+        return f"{title}: {link}"
 
 
 class _SharedGemini:
@@ -162,6 +170,14 @@ class _SharedGemini:
             description="Enables the model to use Google Search to improve the accuracy and recency of responses from the model",
             default=None,
         )
+        grounding_links: Optional[bool] = Field(
+            description="Whether to show the grounding links from the response",
+            default=True
+        )
+        format_links: Optional[bool] = Field(
+            description="Whether to format the grounding links and search recommendation with OSC 8 escape sequences",
+            default=True
+        )
 
     def __init__(self, model_id, can_google_search=False):
         self.model_id = model_id
@@ -250,6 +266,36 @@ class _SharedGemini:
             return f'```\n{part["codeExecutionResult"]["output"].strip()}\n```\n'
         return ""
 
+    def process_grounding(self, event, options):
+        if not options or not self.can_google_search or not options.google_search:
+            return ""
+
+        try:
+            text = ""
+            grounding = event["candidates"][0]["groundingMetadata"]
+            if options.grounding_links and grounding:
+                chunks = grounding["groundingChunks"]
+                if chunks:
+                    text += "\n\nGrounding Sources:\n"
+                    for index, chunk in enumerate(chunks):
+                        if "web" in chunk:
+                            title = chunk['web']['title']
+                            href = chunk['web']['uri']
+                            text += f"{index + 1}. {format_link(options.format_links, title, href)}\n"
+                rendered_content = grounding["searchEntryPoint"]["renderedContent"]
+                if rendered_content:
+                    soup = BeautifulSoup(rendered_content, 'html.parser')
+                    links = soup.find_all('a')
+                    if links:
+                        text += f"\nGoogle Search Suggestions:\n"
+                        for link in links:
+                            title = link.string
+                            href = link['href']
+                            text += f"{format_link(options.format_links, title, href)}\n"
+            return text
+        except KeyError:
+            return ""
+
     def set_usage(self, response):
         try:
             usage = response.response_json[-1].pop("usageMetadata")
@@ -288,7 +334,9 @@ class GeminiPro(_SharedGemini, llm.Model):
                         raise llm.ModelError(event["error"]["message"])
                     try:
                         part = event["candidates"][0]["content"]["parts"][0]
-                        yield self.process_part(part)
+                        text = self.process_part(part)
+                        text += self.process_grounding(event, prompt.options)
+                        yield text
                     except KeyError:
                         yield ""
                     gathered.append(event)
@@ -322,7 +370,9 @@ class AsyncGeminiPro(_SharedGemini, llm.AsyncModel):
                             raise llm.ModelError(event["error"]["message"])
                         try:
                             part = event["candidates"][0]["content"]["parts"][0]
-                            yield self.process_part(part)
+                            text = self.process_part(part)
+                            text + self.process_grounding(event, prompt.options)
+                            yield text
                         except KeyError:
                             yield ""
                         gathered.append(event)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ classifiers = [
 ]
 dependencies = [
     "llm>=0.19",
+    "beautifulsoup4",
     "httpx",
     "ijson"
 ]


### PR DESCRIPTION
Please excuse the unsolicited PR.

A cludgy effort to comply with the spirit, if not the letter‡, of the requirement mentioned by @simonw in https://github.com/simonw/llm-gemini/issues/29#issuecomment-2555959213

- The search suggestion is always displayed. 
- Unless option grounding_links is false, the grounding sources are displayed.
- Unless option format_links is false, the search suggestion and grounding sources are formatted with OSC 8 escape codes to turn them into hyperlinks.

‡ https://ai.google.dev/gemini-api/docs/grounding/search-suggestions?authuser=1#display-requirements says “Display the Search Suggestion exactly as provided and don't make any modifications to colors, fonts, or appearance” but that’s hard to do in a text-based interface.