### PR TITLE
Set search option field name based on model ID

### DIFF
--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -36,6 +36,16 @@ GOOGLE_SEARCH_MODELS = {
     "gemini-2.0-flash",
 }
 
+GOOGLE_SEARCH_TOOL_NAMES = {
+    "gemini-1.5-pro-latest": "google_search_retrieval",
+    "gemini-1.5-flash-latest": "google_search_retrieval",
+    "gemini-1.5-pro-001": "google_search_retrieval",
+    "gemini-1.5-flash-001": "google_search_retrieval",
+    "gemini-1.5-pro-002": "google_search_retrieval",
+    "gemini-1.5-flash-002": "google_search_retrieval",
+    "gemini-2.0-flash-exp": "google_search_retrieval",
+    "gemini-2.0-flash": "google_search",
+}
 
 @llm.hookimpl
 def register_models(register):
@@ -254,7 +264,7 @@ class _SharedGemini:
         if prompt.options and prompt.options.code_execution:
             body["tools"] = [{"codeExecution": {}}]
         if prompt.options and self.can_google_search and prompt.options.google_search:
-            body["tools"] = [{"google_search": {}}]
+            body["tools"] = [{GOOGLE_SEARCH_TOOL_NAMES[self.model_id]: {}}]
         if prompt.system:
             body["systemInstruction"] = {"parts": [{"text": prompt.system}]}
 


### PR DESCRIPTION
The `google_search` option works for `gemini-2.0-flash` but not other models, which expect the field to be named `google_search_retrieval`:

```
% for model in $(< /tmp/gemini_search_models); do echo $model; llm -m $model -o google_search 1 "Today's top 3 headlines, in 3 words each"; done
gemini-1.5-pro-latest
Error: Unable to submit request because Google_search is not supported in this model. Please use google_search_retrieval field instead.. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini
gemini-1.5-flash-latest
Error: Unable to submit request because Google_search is not supported in this model. Please use google_search_retrieval field instead.. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini
gemini-1.5-pro-001
Error: Search as tool is not enabled for models/gemini-1.5-pro-001
gemini-1.5-flash-001
Error: Search as tool is not enabled for models/gemini-1.5-flash-001
gemini-1.5-pro-002
Error: Unable to submit request because Google_search is not supported in this model. Please use google_search_retrieval field instead.. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini
gemini-1.5-flash-002
Error: Unable to submit request because Google_search is not supported in this model. Please use google_search_retrieval field instead.. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini
gemini-2.0-flash
Okay, here are today's top 3 headlines, in 3 words each. To provide you with the most up-to-date information, I will use search queries to identify the top news stories.

Based on the search results, here are three possible top headlines in three words each:

1.  **Trump Ukraine Envoy** (Referring to the Trump envoy's comments on the Ukraine aid freeze.)
2.  **Tariffs Impact Businesses** (Referring to the impact of Trump's tariffs on businesses.)
3.  **Avalanche Death Toll** (Referring to the avalanche in Uttarakhand and the resulting casualties.)
```

The option works as expected for all search models after this change.