### PR TITLE
Add gemini-2.5-pro-exp-03-25

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Other models are:
 - `gemini-2.0-flash-lite` - Gemini 2.0 Flash-Lite
 - `gemini-2.0-pro-exp-02-05` - experimental release of Gemini 2.0 Pro
 - `gemma-3-27b-it` - [Gemma 3](https://blog.google/technology/developers/gemma-3/) 27B
+- `gemini-2.5-pro-exp-03-25` - [Gemini 2.5 Pro Experimental 03-25](https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/)
 
 ### Images, audio and video
 

--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -66,6 +66,8 @@ def register_models(register):
         "gemini-2.0-flash-lite",
         # Released 12th March 2025:
         "gemma-3-27b-it",
+        # Released 25th March 2025:
+        "gemini-2.5-pro-exp-03-25",
     ]:
         can_google_search = model_id in GOOGLE_SEARCH_MODELS
         register(


### PR DESCRIPTION
Adds the newly released model https://blog.google/technology/google-deepmind/gemini-model-thinking-updates-march-2025/


Tested that it works with:
```
uv tool install llm --with . --force-reinstall
```

```
llm-gemini on  gemini is 📦 v0.15 via 🐍 v3.13.2
at 11:16:12 |ψ❯  llm -m  gemini-2.5-pro-exp-03-25 hi
Hello there! How can I help you today?
```

@simonw 