### PR TITLE
Enable search for 2.5 pro

### DIFF
--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -36,6 +36,7 @@ GOOGLE_SEARCH_MODELS = {
     "gemini-1.5-flash-002",
     "gemini-2.0-flash-exp",
     "gemini-2.0-flash",
+    "gemini-2.5-pro-preview-03-25",
 }
 
 


### PR DESCRIPTION
The 2.5 Pro model supports search grounding in the same way as version 2.0. It makes sense to enable that feature.