### PR TITLE
Add (undocumented) timeout option

### DIFF
--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -227,6 +227,14 @@ class _SharedGemini:
             description="Output a valid JSON object {...}",
             default=None,
         )
+        timeout: Optional[int] = Field(
+            description=(
+                "The maximum time in seconds to wait for a response. "
+                "If the model does not respond within this time, "
+                "the request will be aborted."
+            ),
+            default=None,
+        )
 
     class OptionsWithGoogleSearch(Options):
         google_search: Optional[bool] = Field(
@@ -388,7 +396,7 @@ class GeminiPro(_SharedGemini, llm.KeyModel):
         with httpx.stream(
             "POST",
             url,
-            timeout=None,
+            timeout=prompt.options.timeout,
             headers={"x-goog-api-key": self.get_key(key)},
             json=body,
         ) as http_response:
@@ -420,7 +428,7 @@ class AsyncGeminiPro(_SharedGemini, llm.AsyncKeyModel):
             async with client.stream(
                 "POST",
                 url,
-                timeout=None,
+                timeout=prompt.options.timeout,
                 headers={"x-goog-api-key": self.get_key(key)},
                 json=body,
             ) as http_response:


### PR DESCRIPTION
Thanks for making such a great tool and api!

I tested this change minimally and manually via the cli as I wasn't quite sure how you'd want this in the pytest work.
I try to see if there was a way to support this in the llm framework itself and didn't see it.  My assumption
is that even if there was a framework timeout option, each plugin would still need to implement it but let me know.




```text
% llm -m gemini-2.5-pro-exp-03-25 help -o timeout 2
Error: The read operation timed out

% llm -m gemini-2.5-pro-exp-03-25 help -o timeout 10
Okay, I'm here to help!

To give you the best assistance, could you please tell me:

**What do you need help with?**

For example, are you looking for:
*   Information on a specific topic?
*   Help writing something (an email, a story, code, etc.)?
*   An explanation of a concept?
*   Ideas for something?
*   Help solving a problem?
*   Something else entirely?

The more details you can give me, the better I can assist you!

% llm -m gemini-2.5-pro-exp-03-25 help 
Okay, I'm here to help!

To give you the best assistance, I need a little more information. **What can I help you with specifically?**

For example, are you looking for:

*   Information on a topic?
*   Help writing something (an email, a story, code)?
*   An explanation of a concept?
*   Ideas for a project?
*   Help solving a problem?
*   Something else entirely?

The more details you can give me, the better I can assist you!

% llm -m gemini-2.5-pro-exp-03-25 help -o timeout word
Error: timeout
  Input should be a valid integer, unable to parse string as an integer
```