### PR TITLE
Add more models to list of thinkers

### DIFF
--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -54,7 +54,12 @@ GOOGLE_SEARCH_MODELS_USING_SEARCH_RETRIEVAL = {
 }
 
 THINKING_BUDGET_MODELS = {
+    "gemini-2.0-flash-thinking-exp-01-21",
+    "gemini-2.0-flash-thinking-exp-1219",
+    "gemini-2.5-pro-preview-03-25",
+    "gemini-2.5-pro-exp-03-25",
     "gemini-2.5-flash-preview-04-17",
+    "gemini-2.5-pro-preview-05-06",
 }
 
 

--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -56,9 +56,9 @@ GOOGLE_SEARCH_MODELS_USING_SEARCH_RETRIEVAL = {
 THINKING_BUDGET_MODELS = {
     "gemini-2.0-flash-thinking-exp-01-21",
     "gemini-2.0-flash-thinking-exp-1219",
-    "gemini-2.5-pro-preview-03-25",
-    "gemini-2.5-pro-exp-03-25",
     "gemini-2.5-flash-preview-04-17",
+    "gemini-2.5-pro-exp-03-25",
+    "gemini-2.5-pro-preview-03-25",
     "gemini-2.5-pro-preview-05-06",
 }
 


### PR DESCRIPTION
Taken from https://ai.google.dev/gemini-api/docs/models

These are all supported. Tested with:
```py
>>> for m in THINKING_BUDGET_MODELS:
...     print(m)
...     print((r := client.models.generate_content(model=m, contents='think about it, and then say hello', config={'thinking_config': {'thinking_budget': 100}})).text)
...     assert(r.usage_metadata.thoughts_token_count > 0)
```

For context, I needed to do this because I couldn't set a thinking budget on these models, even when the option was already set:
```sh
$ llm models options set gemini-2.5-pro-exp-03-25 thinking_budget 0
Error: thinking_budget
  Extra inputs are not permitted
```