### PR TITLE
Fix a crash when no files were uploaded to the API

### DIFF
--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -660,4 +660,7 @@ def register_commands(cli):
             f"https://generativelanguage.googleapis.com/v1beta/files?key={key}",
         )
         response.raise_for_status()
-        click.echo(json.dumps(response.json()["files"], indent=2))
+        if "files" in response.json():
+            click.echo(json.dumps(response.json()["files"], indent=2))
+        else:
+            click.echo("No files uploaded to the Gemini API.")


### PR DESCRIPTION
If no files have been uploaded via the API, `llm gemini files` crashes with:
```
click.echo(json.dumps(response.json()["files"], indent=2))
                          ~~~~~~~~~~~~~~~^^^^^^^^^             
KeyError: 'files'
```
this PR fixes this small issue.
