### PR TITLE
Add `gemini-3.1-flash-lite-preview`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ for line in lines:
     )
 cog.out("\n".join(to_output))
 ]]] -->
+- `gemini/gemini-3.1-flash-lite-preview`: Gemini 3.1 Flash Lite Preview
 - `gemini/gemini-3.1-pro-preview-customtools`
 - `gemini/gemini-3.1-pro-preview`: Gemini 3.1 Pro Preview
-- `gemini/gemini-3.1-flash-lite-preview`: Gemini 3.1 Flash Lite Preview
 - `gemini/gemini-3-flash-preview`
 - `gemini/gemini-3-pro-preview`: Gemini 3 Pro Preview
 - `gemini/gemini-2.5-flash-lite-preview-09-2025`

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ lines = reversed(result.output.strip().split("\n"))
 to_output = []
 NOTES = {
     "gemini/gemini-3.1-pro-preview": "Gemini 3.1 Pro Preview",
+    "gemini/gemini-3.1-flash-lite-preview": "Gemini 3.1 Flash Lite Preview",
     "gemini/gemini-3-pro-preview": "Gemini 3 Pro Preview",
     "gemini/gemini-flash-latest": "Latest Gemini Flash",
     "gemini/gemini-flash-lite-latest": "Latest Gemini Flash Lite",
@@ -77,6 +78,7 @@ cog.out("\n".join(to_output))
 ]]] -->
 - `gemini/gemini-3.1-pro-preview-customtools`
 - `gemini/gemini-3.1-pro-preview`: Gemini 3.1 Pro Preview
+- `gemini/gemini-3.1-flash-lite-preview`: Gemini 3.1 Flash Lite Preview
 - `gemini/gemini-3-flash-preview`
 - `gemini/gemini-3-pro-preview`: Gemini 3 Pro Preview
 - `gemini/gemini-2.5-flash-lite-preview-09-2025`

--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -55,6 +55,7 @@ GOOGLE_SEARCH_MODELS = {
     "gemini-3-flash-preview",
     "gemini-3.1-pro-preview",
     "gemini-3.1-pro-preview-customtools",
+    "gemini-3.1-flash-lite-preview",
 }
 
 # Older Google models used google_search_retrieval instead of google_search
@@ -92,6 +93,7 @@ MODEL_THINKING_LEVELS = {
     "gemini-3-pro-preview": ["low", "high"],
     "gemini-3.1-pro-preview": ["low", "medium", "high"],
     "gemini-3.1-pro-preview-customtools": ["low", "medium", "high"],
+    "gemini-3.1-flash-lite-preview": ["minimal", "low", "medium", "high"],
 }
 
 NO_VISION_MODELS = {"gemma-3-1b-it", "gemma-3n-e4b-it"}
@@ -211,6 +213,7 @@ def register_models(register):
         # 19th February 2026
         "gemini-3.1-pro-preview",
         "gemini-3.1-pro-preview-customtools",
+        "gemini-3.1-flash-lite-preview",
     ):
         can_google_search = model_id in GOOGLE_SEARCH_MODELS
         can_thinking_budget = model_id in THINKING_BUDGET_MODELS


### PR DESCRIPTION
This supports all 4 thinking modes, using `minimal` by default.

Tested:

```sh
uv run pytest
uv run llm --model gemini-3.1-flash-lite-preview "how to create a zip of files matching a pattern (e.g. ./*, ./.*) into ./files.zip"
uv run llm --model gemini-3.1-flash-lite-preview -o thinking_level minimal "how to create a zip of files matching a pattern (e.g. ./*, ./.*) into ./files.zip"
uv run llm --model gemini-3.1-flash-lite-preview -o thinking_level high "how to create a zip of files matching a pattern (e.g. ./*, ./.*) into ./files.zip"
```