### PR TITLE
Add gemma4 models to MODEL_THINKING_LEVELS

### DIFF
--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -94,6 +94,8 @@ MODEL_THINKING_LEVELS = {
     "gemini-3.1-pro-preview": ["low", "medium", "high"],
     "gemini-3.1-pro-preview-customtools": ["low", "medium", "high"],
     "gemini-3.1-flash-lite-preview": ["minimal", "low", "medium", "high"],
+    "gemma-4-26b-a4b-it": ["minimal", "high"],
+    "gemma-4-31b-it": ["minimal", "high"],
 }
 
 NO_VISION_MODELS = {"gemma-3-1b-it", "gemma-3n-e4b-it"}


### PR DESCRIPTION
As far as I can tell the Gemma 4 models are thinking models and support minimal or high thinking levels. These are available in AI Studio.

So just adding this seems an easy/obvious change. And allows me to set high (the default) or low (which minimises thinking).

uv run pytest ran and also checked the below (and on gemma-4-26b-a4b-it)

```
uv run llm -m gemma-4-31b-it "tell me a joke" -o thinking_level 'minimal'
Why don't scientists trust atoms?
Because they make up everything!
```

```
uv run llm -m gemma-4-31b-it "tell me a joke" -o thinking_level 'high'
*   Goal: Tell a joke.
    *   Constraint: None specified (keep it clean and general).

    *   *Option 1 (Puns):* Why don't scientists trust atoms? Because they make up everything. (Classic, safe).
    *   *Option 2 (Wordplay):* Parallel lines have so much in common. It’s a shame they’ll never meet. (Math humo
r).
    *   *Option 3 (Narrative/Situational):* A guy walks into a bar... (Maybe too long/cliché).
    *   *Option 4 (Animal joke):* What do you call a fake noodle? An impasta. (Cute, short).
    *   The "atoms" joke is a universal favorite and generally well-received.

    *   Joke: Why don't scientists trust atoms?
    *   Punchline: Because they make up everything!Why don't scientists trust atoms?
Because they make up everything!
```
