### PR TITLE
Add include_thoughts option to all thinking capable models

### DIFF
--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -94,6 +94,8 @@ MODEL_THINKING_LEVELS = {
     "gemini-3.1-pro-preview": ["low", "medium", "high"],
     "gemini-3.1-pro-preview-customtools": ["low", "medium", "high"],
     "gemini-3.1-flash-lite-preview": ["minimal", "low", "medium", "high"],
+    "gemma-4-26b-a4b-it": ["minimal", "high"],
+    "gemma-4-31b-it": ["minimal", "high"],
 }
 
 NO_VISION_MODELS = {"gemma-3-1b-it", "gemma-3n-e4b-it"}

--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -485,6 +485,15 @@ class _SharedGemini:
                 ),
             )
 
+        if can_thinking_budget or thinking_levels:
+            extra_fields["include_thoughts"] = (
+                Optional[bool],
+                Field(
+                    description="Include the model's thoughts in the output",
+                    default=None,
+                ),
+            )
+
         if can_media_resolution:
             extra_fields["media_resolution"] = (
                 Optional[MediaResolution],
@@ -649,6 +658,11 @@ class _SharedGemini:
                 thinking_level = thinking_level.value
             generation_config["thinkingConfig"] = {"thinkingLevel": thinking_level}
 
+        if getattr(prompt.options, "include_thoughts", None) is not None:
+            if "thinkingConfig" not in generation_config:
+                generation_config["thinkingConfig"] = {}
+            generation_config["thinkingConfig"]["includeThoughts"] = prompt.options.include_thoughts
+
         config_map = {
             "temperature": "temperature",
             "max_output_tokens": "maxOutputTokens",
@@ -692,6 +706,13 @@ class _SharedGemini:
         return body
 
     def process_part(self, part, response):
+        include_thoughts = getattr(response.prompt.options, "include_thoughts", None)
+        if include_thoughts is None:
+            include_thoughts = True
+
+        if part.get("thought") and not include_thoughts:
+            return ""
+
         if "functionCall" in part:
             tool_call = llm.ToolCall(
                 name=part["functionCall"]["name"],

--- a/tests/test_gemini.py
+++ b/tests/test_gemini.py
@@ -916,6 +916,80 @@ def test_thinking_level_not_in_request_when_not_set():
         assert "thinkingConfig" not in body["generationConfig"]
 
 
+def test_gemma_4_thinking_levels():
+    """Gemma 4 models should have thinking levels minimal and high."""
+    for model_id in ("gemma-4-31b-it", "gemma-4-26b-a4b-it"):
+        model = llm.get_model(model_id)
+        options_class = model.Options
+        assert "thinking_level" in options_class.model_fields
+        field_info = options_class.model_fields["thinking_level"]
+        annotation = field_info.annotation
+        args = getattr(annotation, "__args__", None)
+        thinking_enum = args[0] if args else annotation
+        level_values = {e.value for e in thinking_enum}
+        assert level_values == {"minimal", "high"}
+
+
+def test_include_thoughts_in_request_body():
+    """Include thoughts should be included in the request body when set."""
+    model = llm.get_model("gemma-4-31b-it")
+
+    class MockPrompt:
+        prompt = "test"
+        system = None
+        attachments = []
+        tools = None
+        schema = None
+        tool_results = None
+
+    mock_prompt = MockPrompt()
+    mock_prompt.options = model.Options(include_thoughts=True)
+
+    body = model.build_request_body(mock_prompt, None)
+
+    assert "generationConfig" in body
+    assert "thinkingConfig" in body["generationConfig"]
+    assert body["generationConfig"]["thinkingConfig"]["includeThoughts"] is True
+
+
+def test_thought_filtering():
+    """Thoughts should be filtered out when include_thoughts is False."""
+    model = llm.get_model("gemma-4-31b-it")
+
+    class MockResponse:
+        def __init__(self, include_thoughts):
+            # This is a bit of a hack to mock prompt options
+            class MockOptions:
+                pass
+
+            options = MockOptions()
+            options.include_thoughts = include_thoughts
+
+            class MockPrompt:
+                pass
+
+            self.prompt = MockPrompt()
+            self.prompt.options = options
+
+        def add_tool_call(self, tool_call):
+            pass
+
+    # Thought part
+    thought_part = {"text": "I am thinking", "thought": True}
+    # Regular part
+    regular_part = {"text": "Hello world"}
+
+    # Should show thoughts by default
+    response_default = MockResponse(None)
+    assert model.process_part(thought_part, response_default) == "I am thinking"
+    assert model.process_part(regular_part, response_default) == "Hello world"
+
+    # Should filter thoughts when include_thoughts=False
+    response_hide = MockResponse(False)
+    assert model.process_part(thought_part, response_hide) == ""
+    assert model.process_part(regular_part, response_hide) == "Hello world"
+
+
 @pytest.mark.vcr
 def test_tools_with_gemini_3_thought_signatures():
     """Test that tools work with Gemini 3 models which require thought signatures.


### PR DESCRIPTION
More to potentially comment on or take what is useful than merge. But addresses #66 

The thinking levels don’t guarantee no thinking output or give control over thinking output from llm independently from thinking level, which is something I was interested in. 

With these changes (made with support from Gemini 3.1 Flash itself)  I can toggle thinking output on and off for both gemma-4-31b-it and gemini-3.1-flash-lite-preview with the include_thoughts option. Although there’s an inconsistency in the default behaviour which still confuses me a bit (but that was there to start with) and which may be partially due to differing defaults. See https://ai.google.dev/gemini-api/docs/thinking
Or perhaps I’m just not understanding the code and paths well.

Should Gemma 4 models be treated the same way as other models? Is thinking always filtered? Should we expose the ability to choose? How much should we leave to passing includeThoughts to the API and how much filtering with process_part locally?

Sorry, lots of questions! I’ve not done anything like this for a while, get easily fuzzy and am a bit at the edge of my comfort zone so bear with me :)

Tests (including some new ones) pass and examples of different behaviours and toggling display of thinking on/off independently from thinking level below

 ```
uv run llm -m gemma-4-26b-a4b-it "tell me a joke" -o thinking_level 'minimal' -o include_thoughts True
Why don't scientists trust atoms?
Because they make up everything!

 uv run llm -m gemma-4-26b-a4b-it "tell me a joke" -o thinking_level 'minimal' -o include_thoughts False
Why don't scientists trust atoms?
Because they make up everything!

 uv run llm -m gemma-4-26b-a4b-it "tell me a joke" -o thinking_level 'high' -o include_thoughts False
Why did the scarecrow win an award?
Because he was outstanding in his field!

uv run llm -m gemma-4-26b-a4b-it "tell me a joke" -o thinking_level 'high' -o include_thoughts True
*   Goal: Tell a joke.
    *   Context: General, no specific topic provided.
    *   Constraints: Keep it clean, funny, and concise.
    *   Option 1 (Pun): Why don't scientists trust atoms? Because they make up everything. (Classic, safe).
    *   Option 2 (Wordplay): Parallel lines have so much in common. It’s a shame they’ll never meet. (Math joke, clever).
    *   Option 3 (Narrative): A guy walks into a bar... (Maybe too cliché).
    *   Option 4 (Absurdist): What's orange and sounds like a parrot? A carrot. (Quick, silly).
    *   The "Atoms" joke is a gold standard for AI jokes. It's universally understood and reliable.
    *   Let's try something slightly different but still lighthearted.
    *   *Joke:* Why did the scarecrow win an award? Because he was outstanding in his field!
    *   "Why did the scarecrow win an award? Because he was outstanding in his field!"Why did the scarecrow win an award?
Because he was outstanding in his field!

uv run llm -m gemini-3.1-flash-lite-preview "tell me a joke" -o thinking_level 'high' -o include_thoughts False
I told my wife she was drawing her eyebrows too high.
She looked surprised.

uv run llm -m gemini-3.1-flash-lite-preview "tell me a joke" -o thinking_level 'high -o include_thoughts True
**Initiating Joke Generation**
Okay, I'm starting by analyzing the request for a lighthearted joke appropriate for a general audience. The goal is clear: to be funny. I've begun to select a few joke options, considering the classic and dad joke types as potential starting points. I'm aiming for something easily digestible and instantly enjoyable.
Why don't scientists trust atoms?
Because they make up everything!
```