### PR TITLE
Move the gemini files API key out of the URL and guard against an unset key

### DIFF
--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -919,8 +919,13 @@ def register_commands(cli):
     def files(key):
         "List of files uploaded to the Gemini API"
         key = llm.get_key(key, "gemini", "LLM_GEMINI_KEY")
+        if not key:
+            raise click.ClickException(
+                "You must set the LLM_GEMINI_KEY environment variable or use --key"
+            )
         response = httpx.get(
-            f"https://generativelanguage.googleapis.com/v1beta/files?key={key}",
+            "https://generativelanguage.googleapis.com/v1beta/files",
+            headers={"x-goog-api-key": key},
         )
         response.raise_for_status()
         if "files" in response.json():


### PR DESCRIPTION
Two small things on the `llm gemini files` command:

- The sibling `llm gemini models` command sends the API key as the `x-goog-api-key` header. This one was tacking it onto the URL as `?key=...`, which gets logged by reverse proxies and shows up in shell history. Switched it to use the header too.
- If the env var is unset and `--key` isn't passed, `llm.get_key` returns None and the URL ended up literally as `?key=None`, which the API rejected with a confusing 400. Bail with the same `ClickException` the `models` command uses for the same case.