### PR TITLE
Replay cross-turn history for stateless (messages=) callers

### DIFF
--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -513,8 +513,51 @@ class _SharedGemini:
         if can_vision:
             self.attachment_types = ATTACHMENT_TYPES
 
+    @staticmethod
+    def _history_text_contents(messages):
+        """Prior-turn conversation history as text-only Gemini ``contents``.
+
+        Stateless callers (llm's ``messages=`` chain API, e.g. datasette-agent)
+        pass prior turns on ``prompt.messages`` with an *empty* ``Conversation``,
+        so the ``conversation.responses`` loop below never sees them. We replay
+        those prior turns here as text only: a persisted ``ToolCallPart`` carries
+        no ``thoughtSignature`` (Gemini 3 requires one on ``functionCall`` parts),
+        and the current turn's live tool calls + signatures still come from
+        ``conversation.responses`` / ``prompt``. "Prior turns" is everything
+        before the last ``user`` message; the current turn is built separately.
+        """
+        from llm.parts import TextPart
+
+        last_user = -1
+        for i, msg in enumerate(messages):
+            if getattr(msg, "role", None) == "user":
+                last_user = i
+        contents = []
+        for msg in messages[:last_user] if last_user > 0 else []:
+            role = getattr(msg, "role", None)
+            if role == "system":
+                continue
+            text = "".join(
+                p.text for p in msg.parts if isinstance(p, TextPart) and p.text
+            )
+            if not text:
+                continue
+            contents.append(
+                {
+                    "role": "model" if role == "assistant" else "user",
+                    "parts": [{"text": text}],
+                }
+            )
+        return contents
+
     def build_messages(self, prompt, conversation):
         messages = []
+        # Replay cross-turn history for stateless callers (prompt.messages with
+        # an empty conversation). Without this they have no memory across turns.
+        if getattr(prompt, "_explicit_messages", None) is not None and not (
+            conversation and conversation.responses
+        ):
+            messages.extend(self._history_text_contents(prompt.messages))
         if conversation:
             for response in conversation.responses:
                 parts = []

--- a/tests/test_gemini.py
+++ b/tests/test_gemini.py
@@ -945,3 +945,37 @@ def test_tools_with_gemini_3_thought_signatures():
     assert first_response.tool_calls()[0].name == "multiply"
     # The result should be 15
     assert "15" in text
+
+
+def test_build_messages_replays_stateless_history():
+    """Stateless callers pass prior turns via messages= (prompt.messages) with an
+    empty Conversation. build_messages must replay that history as text so the
+    model has memory across turns. Regression test for the 'amnesia' bug where
+    llm-gemini only read conversation.responses and dropped prompt.messages."""
+    from llm.parts import Message, TextPart
+
+    model = llm.get_model("gemini-2.5-flash")
+
+    chain = [
+        Message(role="user", parts=[TextPart(text="How many products in Germany?")]),
+        Message(role="assistant", parts=[TextPart(text="2,100 products.")]),
+        Message(role="user", parts=[TextPart(text="What was my first question?")]),
+    ]
+
+    class MockPrompt:
+        prompt = "What was my first question?"
+        system = None
+        attachments = []
+        tools = None
+        schema = None
+        tool_results = None
+        _explicit_messages = chain
+        messages = chain
+
+    contents = model.build_messages(MockPrompt(), None)
+
+    # Prior turns replayed as history, then the current turn last.
+    assert contents[0] == {"role": "user", "parts": [{"text": "How many products in Germany?"}]}
+    assert contents[1] == {"role": "model", "parts": [{"text": "2,100 products."}]}
+    assert contents[-1]["role"] == "user"
+    assert {"text": "What was my first question?"} in contents[-1]["parts"]


### PR DESCRIPTION
Fixes #135.

`build_messages` only read `conversation.responses`, so callers using llm's stateless chain API (`model.chain(text, messages=prior_turns)` with an empty `Conversation` — e.g. datasette-agent) had all prior history silently dropped: the model only ever saw the current turn. llm core's OpenAI model already builds from `prompt.messages`; this brings Gemini in line for the history it can safely replay.

### Change

`build_messages` now **prepends prior-turn history from `prompt.messages` as text** — everything before the last `user` message — when an explicit chain is present and `conversation.responses` is empty. The current turn (incl. live tool calls + their `thoughtSignature`) is still built from `conversation.responses`/`prompt` exactly as before.

Tool-call/result parts from history are intentionally omitted: a persisted `ToolCallPart` has no `thoughtSignature` (Gemini 3 requires it on `functionCall` parts — see the note in #135), so replaying them would error. This keeps the PR to the safe, reported fix (text memory) without disturbing tool behaviour.

### Testing

- New network-free regression test `test_build_messages_replays_stateless_history`.
- Full suite: 36 passed (35 existing + 1 new); no change to the conversation / Gemini-3 thought-signature paths.
- Standalone reproducer from #135 flips from `history reaches the model? False` → `True` with this change.