### PR TITLE
AsyncGeminiPro.execute: record the resolved model too

### DIFF
--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -813,6 +813,8 @@ class AsyncGeminiPro(_SharedGemini, llm.AsyncKeyModel):
                             gathered.append(event)
                         events.clear()
         response.response_json = gathered[-1]
+        resolved_model = gathered[-1]["modelVersion"]
+        response.set_resolved_model(resolved_model)
         self.set_usage(response)
 
 


### PR DESCRIPTION
4091d9e (\"New models + resolved model recording, refs #104, closes #105\") added the `set_resolved_model` call to `GeminiPro.execute`, but the parallel `AsyncGeminiPro.execute` was missed. So `await async_model.prompt(...)` leaves `response.resolved_model` unset even though `gathered[-1][\"modelVersion\"]` is right there.

Two-line fix that mirrors the sync version. I didn't add an async cassette since recording one needs a real API key, but the existing `test_resolved_model` exercises the same codepath shape on the sync side.

Refs #105.