### PR TITLE
Add gemini-3.6-flash and gemini-3.5-flash-lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ for line in lines:
     )
 cog.out("\n".join(to_output))
 ]]] -->
+- `gemini/gemini-3.5-flash-lite`
+- `gemini/gemini-3.6-flash`
 - `gemini/gemini-3.5-flash`
 - `gemini/gemini-3.1-flash-lite`
 - `gemini/gemma-4-31b-it`

--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -58,6 +58,8 @@ GOOGLE_SEARCH_MODELS = {
     "gemini-3.1-flash-lite-preview",
     "gemini-3.1-flash-lite",
     "gemini-3.5-flash",
+    "gemini-3.6-flash",
+    "gemini-3.5-flash-lite",
 }
 
 # Older Google models used google_search_retrieval instead of google_search
@@ -98,6 +100,8 @@ MODEL_THINKING_LEVELS = {
     "gemini-3.1-flash-lite-preview": ["minimal", "low", "medium", "high"],
     "gemini-3.1-flash-lite": ["minimal", "low", "medium", "high"],
     "gemini-3.5-flash": ["minimal", "low", "medium", "high"],
+    "gemini-3.6-flash": ["minimal", "low", "medium", "high"],
+    "gemini-3.5-flash-lite": ["minimal", "low", "medium", "high"],
 }
 
 NO_VISION_MODELS = {"gemma-3-1b-it", "gemma-3n-e4b-it"}
@@ -226,6 +230,9 @@ def register_models(register):
         "gemini-3.1-flash-lite",
         # 19th Mary 2026
         "gemini-3.5-flash",
+        # 21st July 2026
+        "gemini-3.6-flash",
+        "gemini-3.5-flash-lite",
     ):
         can_google_search = model_id in GOOGLE_SEARCH_MODELS
         can_thinking_budget = model_id in THINKING_BUDGET_MODELS


### PR DESCRIPTION
Both models announced 21st July 2026:
https://blog.google/innovation-and-ai/models-and-research/gemini-3-6-flash-3-5-flash-lite-3-5-flash-cyber/

Both support Google Search grounding and thinking levels
(minimal, low, medium, high) - manually tested against the live API.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F8pT62sCrdSiDf1nv5MSP8