### PR TITLE
fix: Report blocked Gemini prompts as errors

### DIFF
--- a/llm_gemini.py
+++ b/llm_gemini.py
@@ -959,6 +959,15 @@ class _SharedGemini:
 
         yield from events
 
+    def validate_response_event(self, event):
+        if not isinstance(event, dict):
+            return
+        if "error" in event:
+            raise llm.ModelError(event["error"]["message"])
+        block_reason = (event.get("promptFeedback") or {}).get("blockReason")
+        if block_reason:
+            raise llm.ModelError(f"Gemini blocked the prompt: {block_reason}")
+
     def set_usage(self, response):
         try:
             # Don't record the "content" key from that last candidate
@@ -1006,8 +1015,7 @@ class GeminiPro(_SharedGemini, llm.KeyModel):
                 coro.send(chunk)
                 if events:
                     for event in events:
-                        if isinstance(event, dict) and "error" in event:
-                            raise llm.ModelError(event["error"]["message"])
+                        self.validate_response_event(event)
                         try:
                             yield from self.process_candidates(
                                 event["candidates"], response
@@ -1042,8 +1050,7 @@ class AsyncGeminiPro(_SharedGemini, llm.AsyncKeyModel):
                     coro.send(chunk)
                     if events:
                         for event in events:
-                            if isinstance(event, dict) and "error" in event:
-                                raise llm.ModelError(event["error"]["message"])
+                            self.validate_response_event(event)
                             try:
                                 for stream_event in self.process_candidates(
                                     event["candidates"], response

--- a/tests/test_gemini.py
+++ b/tests/test_gemini.py
@@ -1177,6 +1177,37 @@ class _NoLocalToolCallsResponse:
         raise AssertionError("Server-side tools must not be registered as local calls")
 
 
+@pytest.mark.parametrize("block_reason", ("PROHIBITED_CONTENT", "SAFETY"))
+def test_validate_response_event_raises_for_blocked_prompt(block_reason):
+    model = llm.get_model("gemini-3.6-flash")
+
+    with pytest.raises(
+        llm.ModelError, match=f"Gemini blocked the prompt: {block_reason}"
+    ):
+        model.validate_response_event(
+            {"promptFeedback": {"blockReason": block_reason}}
+        )
+
+
+def test_validate_response_event_allows_candidates():
+    model = llm.get_model("gemini-3.6-flash")
+    event = {
+        "candidates": [{"content": {"parts": [{"text": "Hello from Gemini"}]}}]
+    }
+
+    model.validate_response_event(event)
+    events = list(model.process_candidates(event["candidates"], response=None))
+
+    assert [event.chunk for event in events] == ["Hello from Gemini"]
+
+
+def test_validate_response_event_preserves_api_error_message():
+    model = llm.get_model("gemini-3.6-flash")
+
+    with pytest.raises(llm.ModelError, match="^Existing API error$"):
+        model.validate_response_event({"error": {"message": "Existing API error"}})
+
+
 def test_native_server_tool_call_and_response_events():
     model = llm.get_model("gemini-3.6-flash")
     raw_call = {


### PR DESCRIPTION
Add shared response-event validation in `_SharedGemini` that recognizes a non-empty `promptFeedback.blockReason` and raises `llm.ModelError` with a concise message that includes the provider's reason. Gemini can return a successful HTTP response containing `promptFeedback.blockReason` but no candidates when it rejects the prompt before generation.

A response event with `promptFeedback.blockReason` set to `PROHIBITED_CONTENT` raises `llm.ModelError`, and the message identifies `PROHIBITED_CONTENT` instead of yielding an empty response; A response event with a different non-empty block reason follows the same generic error path, proving the behavior is not hard-coded to the reported example.

Closes #80
